### PR TITLE
fix: change the footer trademark year and message

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -166,9 +166,9 @@ const App = () => (
       icon: <FontAwesomeIcon icon={faLanguage} size="2x" className="text-primary" />,
       onLanguageSelected: () => {},
     }}
-    copyright="© 2012–2019 edX Inc."
+    copyright={`© ${new Date().getFullYear()} edX Inc. All rights reserved.`}
     trademark={(
-      <React.Fragment>EdX, Open edX, and MicroMasters are registered trademarks of edX Inc. | 深圳市恒宇博科技有限公司 <a href="http://www.beian.miit.gov.cn">粤ICP备17044299号-2</a></React.Fragment>
+      <React.Fragment>深圳市恒宇博科技有限公司 <a href="http://www.beian.miit.gov.cn">粤ICP备17044299号-2</a></React.Fragment>
     )}
   />
 );


### PR DESCRIPTION
Quick change the copyright message.

<img width="1299" alt="image" src="https://user-images.githubusercontent.com/16495365/70737429-75090980-1ce0-11ea-86cb-ec92489b4460.png">
